### PR TITLE
Remove spacing from string representation of field_list and filter_list

### DIFF
--- a/oaxmlapi/commands.py
+++ b/oaxmlapi/commands.py
@@ -91,10 +91,10 @@ class Read(object):
                     elem.append(item['datatype'])
 
             if field_list:
-                attribs['field'] = ', '.join(field_list)
+                attribs['field'] = ','.join(field_list)
 
             if filter_list:
-                attribs['filter'] = ', '.join(filter_list)
+                attribs['filter'] = ','.join(filter_list)
 
         # add all attribs to the XML element
         elem.attrib = attribs


### PR DESCRIPTION
The spaces cause issues with the XML API.  See the following example to demonstrate the issue:

[Incorrect]
```
<?xml version="1.0" encoding="utf-8" standalone="yes"?><request API_ver="1.0" client="XYZ" client_ver="1.0" key="XYZ" namespace="default">
<Auth><Login><company>XYZ</company><user>XYZ</user><password>XYZ</password></Login></Auth>
<Read enable_custom="1" field="date, date" filter="newer-than, older-than" limit="0, 1000" method="all" type="Task">
    <Date>
        <year>2014</year>
        <day>31</day>
        <month>12</month>
    </Date>
    <Date>
        <year>2015</year>
        <day>06</day>
        <month>01</month>
    </Date>
</Read>
</request>
```

versus [Correct] 

```
<?xml version="1.0" encoding="utf-8" standalone="yes"?><request API_ver="1.0" client="XYZ" client_ver="1.0" key="XYZ" namespace="default">
<Auth><Login><company>XYZ</company><user>XYZ</user><password>XYZ</password></Login></Auth>
<Read enable_custom="1" field="date,date" filter="newer-than,older-than" limit="0, 1000" method="all" type="Task">
    <Date>
        <year>2014</year>
        <day>31</day>
        <month>12</month>
    </Date>
    <Date>
        <year>2015</year>
        <day>06</day>
        <month>01</month>
    </Date>
</Read>
</request>
```