### PR TITLE
Fix print error on Application class

### DIFF
--- a/oaxmlapi/connections.py
+++ b/oaxmlapi/connections.py
@@ -27,7 +27,7 @@ class Application(object):
         self.key = key
 
     def __str__(self):
-        return "%s (v%s)" % (self.client, self.version)
+        return "%s (v%s)" % (self.client, self.client_version)
 
 
 class Auth(object):


### PR DESCRIPTION
Changed from `return "%s (v%s)" % (self.client, self.version)` to `return "%s (v%s)" % (self.client, self.client_version)`