### PR TITLE
Add support for python3.6

### DIFF
--- a/oaxmlapi/connections.py
+++ b/oaxmlapi/connections.py
@@ -237,7 +237,7 @@ class Request(object):
         Return a string containing XML tags.
 
         """
-        header = '<?xml version="1.0" encoding="utf-8" standalone="yes"?>'
+        header = b'<?xml version="1.0" encoding="utf-8" standalone="yes"?>'
         return header + ET.tostring(self.request(), 'utf-8')
 
     def prettify(self):


### PR DESCRIPTION
API output is treated as bytes, son when defining header variable with string causes python 3 to get a utf-8 string which cannot be concatenated with a bytes object. The simplest solution in my opinion is to declare set header as a byte string.